### PR TITLE
fix(scoreRank): mysql8.0保留字段 特殊处理

### DIFF
--- a/src/main/java/com/scu/gkvr_system_backend/pojo/ScoreRank.java
+++ b/src/main/java/com/scu/gkvr_system_backend/pojo/ScoreRank.java
@@ -1,5 +1,6 @@
 package com.scu.gkvr_system_backend.pojo;
 
+import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
@@ -20,8 +21,10 @@ public class ScoreRank implements Serializable {
 
     private Integer num;
 
+    @TableField("`rank`")
     private Integer rank;
 
+    @TableField("`rank_range`")
     private String rankRange;
 
     private String batchName;


### PR DESCRIPTION
1.  标题
修复与 MySQL 8.0 保留字段冲突的 scoreRank 字段处理
2. 描述
问题背景:
在 MySQL 8.0 中，rank 和 rank_range 是保留关键字。当我们在 SQL 查询中直接使用这些字段名时，MySQL 会将其识别为保留关键字，从而引发 SQL 语法错误。
在 scoreRank 实体类中，rank 和 rank_range 这两个字段会导致 SQL 查询语法错误，进而影响数据查询功能。
解决方案:
使用 MyBatis-Plus 的 @TableField 注解，将 rank 和 rank_range 字段使用反引号包裹起来，明确表示这是数据库中的列名，而不是 MySQL 的保留关键字。
修改后的 ScoreRank 实体类确保与 MySQL 8.0 的兼容性，避免 SQL 错误。

![image](https://github.com/user-attachments/assets/e1426680-fd9d-4382-bd48-7dd3d338e117)

